### PR TITLE
fix: correct spelling from 'user-invocable' to 'user-invokable'

### DIFF
--- a/gem-browser-tester.agent.md
+++ b/gem-browser-tester.agent.md
@@ -2,7 +2,7 @@
 description: "Automates browser testing, UI/UX validation using browser automation tools and visual verification techniques"
 name: gem-browser-tester
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-devops.agent.md
+++ b/gem-devops.agent.md
@@ -2,7 +2,7 @@
 description: "Manages containers, CI/CD pipelines, and infrastructure deployment"
 name: gem-devops
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-documentation-writer.agent.md
+++ b/gem-documentation-writer.agent.md
@@ -2,7 +2,7 @@
 description: "Generates technical docs, diagrams, maintains code-documentation parity"
 name: gem-documentation-writer
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-implementer.agent.md
+++ b/gem-implementer.agent.md
@@ -2,7 +2,7 @@
 description: "Executes TDD code changes, ensures verification, maintains quality"
 name: gem-implementer
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-orchestrator.agent.md
+++ b/gem-orchestrator.agent.md
@@ -2,7 +2,7 @@
 description: "Coordinates multi-agent workflows, delegates tasks, synthesizes results via runSubagent"
 name: gem-orchestrator
 disable-model-invocation: true
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-planner.agent.md
+++ b/gem-planner.agent.md
@@ -2,7 +2,7 @@
 description: "Creates DAG-based plans with pre-mortem analysis and task decomposition from research findings"
 name: gem-planner
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-researcher.agent.md
+++ b/gem-researcher.agent.md
@@ -2,7 +2,7 @@
 description: "Research specialist: gathers codebase context, identifies relevant files/patterns, returns structured findings"
 name: gem-researcher
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>

--- a/gem-reviewer.agent.md
+++ b/gem-reviewer.agent.md
@@ -2,7 +2,7 @@
 description: "Security gatekeeper for critical tasks—OWASP, secrets, compliance"
 name: gem-reviewer
 disable-model-invocation: false
-user-invocable: true
+user-invokable: true
 ---
 
 <agent>


### PR DESCRIPTION
## Issue
All agent configuration files were using the incorrect spelling **`user-invocable`** instead of the correct **`user-invokable`** (with 'k').

## Root Cause
This is a spelling misconfiguration. According to GitHub Copilot's official documentation and industry-wide programming standards, the term **'invokable'** (with 'k') is the correct spelling, meaning 'able to be invoked.'

## Evidence
-  **GitHub Docs**: [Custom agents configuration](https://docs.github.com/en/copilot/reference/custom-agents-configuration)
-  **Microsoft Learn**: [Use Agent Mode documentation](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-mode)
-  **Programming terminology**: 'invokable' is consistently used across software development literature

The term 'invocable' (with 'c') is rarely used in technical contexts and is not the standard.

## Changes Made
Fixed spelling in all 8 agent configuration files:
- `gem-browser-tester.agent.md`
- `gem-devops.agent.md`
- `gem-documentation-writer.agent.md`
- `gem-implementer.agent.md`
- `gem-orchestrator.agent.md`
- `gem-planner.agent.md`
- `gem-researcher.agent.md`
- `gem-reviewer.agent.md`

Changed: `user-invocable: true`  `user-invokable: true`

## Impact
This ensures the agent configurations follow GitHub Copilot's official specification and prevents potential issues with agent invocation.